### PR TITLE
Rewrote ve.js...

### DIFF
--- a/js/ve.js
+++ b/js/ve.js
@@ -1,17 +1,57 @@
-Ve = function(language) {
-  return({
-    'words': function(text, callback) {
-      //var url = 'http://ve.kimtaro.com:4567/' + language + '/words';
-      var url = 'http://localhost:4567/' + language + '/words';
-      $.ajax({
-        url: url,
-        data: {'text': text},
-        dataType: 'json',
-		    type: 'POST',
-        success: function(data){
-          callback(data);
-       }
-      });
-    }
-  });
-};
+/**
+ *	ve.js
+ *
+ *	Communicates with a Sinatra-server to facilitate linguistic
+ *	parsing tech in JS.
+ *
+ *	@Author: Kim Ahlstrom
+ *	@Author: Ryan McGrath <ryan@venodesigns.net>
+ *	@Requires: Nothing
+ */
+
+;(function(w, d, undefined) {
+	var Ve = w.Ve = function Ve(language) {
+		this.language = language;
+		this.url = 'http://localhost:4567/';
+		return this;
+	};
+	
+	Ve.prototype = {
+		words: function(text, callbackfn) {
+			// Need to utf8-encode stuff at this point...
+			jsonp(this.url + this.language + '/words?text=' + text, callbackfn);
+			return this;
+		}
+	};
+
+	var jsonp = function jsonp(src, callbackfn) {
+		var newScript = document.createElement("script"),
+			callback = 've_callback_' + +new Date();
+		
+	    newScript.type = "text/javascript";
+	    newScript.setAttribute("async", "true");
+	    newScript.setAttribute("src", src + '&callback=' + callback);
+		window[callback] = callbackfn;
+
+	    /**
+	     *  Automagically handle cleanup of injected script tags, so we don't litter someone's DOM
+	     *  with our stuff. This branches for various reasons - could be a bit cleaner.
+	     */
+	    if(newScript.readyState) {
+	        newScript.onreadystatechange = function() {
+	            if(/loaded|complete/.test(newScript.readyState)) {
+	                newScript.onreadystatechange = null;
+	                document.documentElement.firstChild.removeChild(newScript);
+					window[callback] = null;
+	            }
+	        }
+	    } else {
+	        newScript.addEventListener("load", function() {
+	            document.documentElement.firstChild.removeChild(newScript);
+				window[callback] = null;
+	        }, false);
+	    }
+
+	    document.documentElement.firstChild.appendChild(newScript);
+	}
+})(window, document, 'undefined');


### PR DESCRIPTION
No jQuery dependency, more standalone. Doesn't do utf8 encoding/decoding yet, but structurally a little nicer for anyone who wants to use it in a random environment. Since it's cross domain it only works with GET, so... conceivably a browser could hit a limit in the query string.

If you support CORS headers on the Sinatra side, a POST XMLHttpRequest would be feasible here. Feel free to merge if you like.

``` javascript
new Ve('ja').words('ありがとう', function(words) {
    // do stuffs
});
```
