### PR TITLE
Include regex for Ve::PartOfSpeech.name to separate words with space

### DIFF
--- a/lib/part_of_speech.rb
+++ b/lib/part_of_speech.rb
@@ -2,7 +2,7 @@ class Ve
   class PartOfSpeech
     
     def self.name
-      self.to_s.split('::').last.downcase
+      self.to_s.split('::').last.gsub(/(?<=[A-Za-z])(?=[A-Z])/, ' ').downcase # RegEx adds spaces before uppercase letters. Ex: Ve::PartOfSpeech::ProperNoun.name => "proper noun"
     end
     
     class Noun < PartOfSpeech; end


### PR DESCRIPTION
For example

```
Ve::PartOfSpeech::ProperNoun.name => "proper noun"
```

With the current implementation the following yields

```
Ve::PartOfSpeech::ProperNoun.name => "propernoun"
```

I tried looking into the Ruby documentation for humanizing strings with uppercase, but didn't find any. Therefore, the use of ugly regex.
