### PR TITLE
Explicit licensing

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+
+The MIT License (MIT)
+Copyright © 2015 Kim Ahlström <kim.ahlstrom@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/ve.gemspec
+++ b/ve.gemspec
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = 've'
   s.version     = '0.0.3'

--- a/ve.gemspec
+++ b/ve.gemspec
@@ -3,10 +3,10 @@ Gem::Specification.new do |s|
   s.name        = 've'
   s.version     = '0.0.3'
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Kim Ahlström"]
-  s.email       = ["kim.ahlstrom@gmail.com"]
+  s.authors     = ['Kim Ahlström']
+  s.email       = ['kim.ahlstrom@gmail.com']
   s.license     = 'MIT'
-  s.homepage    = "http://github.com/kimtaro/ve"
+  s.homepage    = 'http://github.com/kimtaro/ve'
   s.summary     = 'Ve is a linguistic framework for programmers'
   s.description = 'Ve is a linguistic framework for programmers.'
   
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # For C extensions
-  # s.extensions = "ext/extconf.rb"
+  # s.extensions = 'ext/extconf.rb'
 end

--- a/ve.gemspec
+++ b/ve.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/kimtaro/ve'
   s.summary     = 'Ve is a linguistic framework for programmers'
   s.description = 'Ve is a linguistic framework for programmers.'
-  
+
   # The list of files to be contained in the gem
   s.files         = `git ls-files`.split("\n")
   # s.executables   = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   # s.extensions    = `git ls-files ext/extconf.rb`.split("\n")
-  
+
   s.require_paths = ['lib']
 
   # For C extensions

--- a/ve.gemspec
+++ b/ve.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Kim Ahlström"]
   s.email       = ["kim.ahlstrom@gmail.com"]
+  s.license     = 'MIT'
   s.homepage    = "http://github.com/kimtaro/ve"
   s.summary     = 'Ve is a linguistic framework for programmers'
   s.description = 'Ve is a linguistic framework for programmers.'


### PR DESCRIPTION
`Readme.md` indicated the code was MIT-licensed, but there was no license included in either the repository, or in the gem specification. This PR adds those, along with some minor stylistic changes in separate commits if you'd prefer to cherry-pick around them.