### PR TITLE
Dependency updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "json"
+gem 'json'
 
 group :server do
-  gem "sinatra", '~> 1.3.1'
-  gem "rack-cors", '~> 0.2.4'
+  gem 'sinatra', '~> 1.3.1'
+  gem 'rack-cors', '~> 0.2.4'
 end
 
 group :test do
-  gem "rake", '~> 10.3.2'
-  gem "mocha", '~> 1.1.0', require: false
+  gem 'rake', '~> 10.3.2'
+  gem 'mocha', '~> 1.1.0', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'json'
+gem 'json', '~> 1.8'
 
 group :server do
   gem 'sinatra', '~> 1.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "json"
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ end
 
 group :test do
   gem "rake", '~> 10.3.2'
-  gem "mocha", '~> 1.1.0', :require => false
+  gem "mocha", '~> 1.1.0', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ end
 
 group :test do
   gem 'rake', '~> 10.3.2'
+  gem 'minitest', '~> 5.8.3'
   gem 'mocha', '~> 1.1.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    json (1.6.1)
+    json (1.8.3)
     metaclass (0.0.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -21,7 +21,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json
+  json (~> 1.8)
   mocha (~> 1.1.0)
   rack-cors (~> 0.2.4)
   rake (~> 10.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     json (1.8.3)
     metaclass (0.0.4)
+    minitest (5.8.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     rack (1.3.5)
@@ -22,6 +23,7 @@ PLATFORMS
 
 DEPENDENCIES
   json (~> 1.8)
+  minitest (~> 5.8.3)
   mocha (~> 1.1.0)
   rack-cors (~> 0.2.4)
   rake (~> 10.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     json (1.6.1)
     metaclass (0.0.4)


### PR DESCRIPTION
This adds a missing dependency that prevented tests from running when `BUNDLE_DISABLE_SHARED_GEMS` was set. It also updates the dependency on `json` to the current version (`1.6.1` failed to build for me, and tests pass with `1.8.3`).

There are also a few minor stylistic changes that can be omitted if you prefer. They are in their own commits.