### PR TITLE
Fix link to installation instructions for MeCab. Resolves #34

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ language parsers. You **must** install FreeLing for English or MeCab for Japanes
 
 Installation instructions for FreeLing can be found [here](http://nlp.lsi.upc.edu/freeling/index.php?option=com_content&task=view&id=15&Itemid=44).
 
-Installation instruction for MeCab can be found [here](http://mecab.googlecode.com/svn/trunk/mecab/doc/index.html#install).
+Installation instruction for MeCab can be found [here](https://taku910.github.io/mecab/#install).
 
 ### Installing with HomeBrew
 


### PR DESCRIPTION
Repository has been moved from Google Code to GitHub. This fixes #34.